### PR TITLE
fix: using correct id to navigate to useful links

### DIFF
--- a/src/components/links-uteis.astro
+++ b/src/components/links-uteis.astro
@@ -34,7 +34,7 @@ const links: Array<LinksUteisItem> = [
 <ContentSection
   title="Links Úteis"
   description="Links úteis para quem está começando na área de programação."
-  id="Links"
+  id="links"
   align="start"
   extraclass="xl:pl-8 2xl:mx-40"
 >

--- a/src/components/menu.astro
+++ b/src/components/menu.astro
@@ -6,7 +6,7 @@ import type { NavItem } from "../types";
 const navItems: Array<NavItem> = [
   { title: "Como Participar", url: "#comoParticipar" },
   { title: "Benefícios", url: "#beneficios" },
-   { title: "Links Úteis", url: "#linksUteis" },
+  { title: "Links Úteis", url: "#links" },
   /* { title: "Perguntas", url: "#perguntas" }, */
 ];
 ---


### PR DESCRIPTION
The previous link was referring to an incorrect `id` to navigate.

