### PR TITLE
fix: Inserting accessibility into the instagram link

### DIFF
--- a/src/components/participar.astro
+++ b/src/components/participar.astro
@@ -63,7 +63,7 @@ import instagram from "../assets/instagramExemplo.gif";
                 <p>
                   <span>Poste um story</span> com seu progresso todos os dias com a hashtag <span>#100DiasDeCodigo</span>
                   marcando a 
-                  <a class="instagram" target="_blank" href="https://instagram.com/heartdevs">He4rt Developers</a>
+                  <a class="instagram" target="_blank" href="https://instagram.com/heartdevs">@heartdevs</a>
                   no Instagram para que possamos repostar! Crie uma aba #100DiasDeCodigo nos <span>destaques</span> e adicione diáriamente seu progresso!
               </div>
               </p>
@@ -131,9 +131,21 @@ import instagram from "../assets/instagramExemplo.gif";
   }
 
   .instagram {
-    text-decoration: underline;
+    text-decoration: none;
     background: linear-gradient(157deg, rgba(249,206,52,1) 0%, rgba(238,42,112,1) 50%, rgba(98,40,208,1) 100%);
     background: -webkit-linear-gradient(157deg, rgba(249,206,52,1) 0%, rgba(238,42,112,1) 50%, rgba(98,40,208,1) 100%);
+    background-clip: text;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  .instagram:focus:not(:focus-visible) {
+    outline: none;
+    box-shadow: 1px 1px 5px rgba(1, 1, 0, .7);
+  }
+
+  .instagram::selection {
+    background: linear-gradient(157deg, rgba(249,206,52,1) 0%, rgba(238,42,112,1) 50%, rgba(98,40,208,1) 100%);
     background-clip: text;
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;


### PR DESCRIPTION
The outline view was inserted just to keyboard view, since using the outline with the mouse means that feedback to the mouse user is not necessary.

To know more: https://blog.chromium.org/2020/09/giving-users-and-developers-more.html?

Corrections inserted:

- [x] When selecting the text, the background will not cover the view.
- [x] Outline will not form a line around the link using the mouse, it will only form a line using the keyboard
- [x] Name change suggested live

Preview:
![image](https://github.com/DanielHe4rt/100DiasDeCodigo-landing/assets/16712399/cedee71e-e411-4db7-b93d-0d2280841d32)

Reason for change: https://twitter.com/LeaVerou/status/1045768279753666562
